### PR TITLE
Fix /diff with special filenames

### DIFF
--- a/codex-cli/src/utils/get-diff.ts
+++ b/codex-cli/src/utils/get-diff.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 
 // The objects thrown by `child_process.execSync()` are `Error` instances that
 // include additional, undocumented properties such as `status` (exit code) and
@@ -90,11 +90,15 @@ export function getGitDiff(): {
         // `git diff --color --no-index /dev/null <file>` exits with status 1
         // when differences are found, so we capture stdout from the thrown
         // error object instead of letting it propagate.
-        execSync(`git diff --color --no-index -- "${nullDevice}" "${file}"`, {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "ignore"],
-          maxBuffer: 10 * 1024 * 1024,
-        });
+        execFileSync(
+          "git",
+          ["diff", "--color", "--no-index", "--", nullDevice, file],
+          {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+            maxBuffer: 10 * 1024 * 1024,
+          },
+        );
       } catch (err) {
         if (
           isExecSyncError(err) &&

--- a/codex-cli/tests/get-diff-special-chars.test.ts
+++ b/codex-cli/tests/get-diff-special-chars.test.ts
@@ -1,0 +1,21 @@
+import { getGitDiff } from "../src/utils/get-diff";
+import { execFileSync } from "node:child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { test, expect } from "vitest";
+
+test("getGitDiff handles filenames with special characters", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "git-diff-test-"));
+  const prevCwd = process.cwd();
+  try {
+    process.chdir(tmpDir);
+    execFileSync("git", ["init"]);
+    fs.writeFileSync("a$b.txt", "hello world");
+    const { diff } = getGitDiff();
+    expect(diff).toContain("a$b.txt");
+  } finally {
+    process.chdir(prevCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- use `execFileSync` to avoid shell expansion in `getGitDiff`
- add regression test for filenames containing `$`

## Testing
- `pnpm test tests/get-diff-special-chars.test.ts`